### PR TITLE
Update __init__.py

### DIFF
--- a/ovos_PHAL_plugin_mk1/__init__.py
+++ b/ovos_PHAL_plugin_mk1/__init__.py
@@ -462,9 +462,13 @@ class MycroftMark1(PHALPlugin):
             start = message.data['start']
             visemes = message.data['visemes']
             self.showing_visemes = True
+            previous_end = -1
             for code, end in visemes:
                 if not self.showing_visemes:
                     break
+                if end < previous_end:
+                    start = time.time()
+                previous_end = end
                 if time.time() < start + end:
                     self.writer.write('mouth.viseme=' + code)
                     sleep(start + end - time.time())


### PR DESCRIPTION
Change made to handle case where an utterance contains multiple sentences.  Mimic1 resets the duration back to zero when a new sentence is started.  This fix detects that and then resets the start timer to the current time.  Otherwise, the time.time()<start+end test would fail and the routine would end early.