### PR TITLE
use a thread to not block FakeBus (eg, voice sat)

### DIFF
--- a/ovos_PHAL_plugin_mk1/__init__.py
+++ b/ovos_PHAL_plugin_mk1/__init__.py
@@ -464,6 +464,7 @@ class MycroftMark1(PHALPlugin):
             visemes = message.data['visemes']
 
             def animate_mouth():
+                nonlocal start, visemes
                 self.showing_visemes = True
                 previous_end = -1
                 for code, end in visemes:

--- a/ovos_PHAL_plugin_mk1/__init__.py
+++ b/ovos_PHAL_plugin_mk1/__init__.py
@@ -4,6 +4,7 @@ from time import sleep
 
 import serial
 from ovos_bus_client.message import Message
+from ovos_utils import create_daemon
 from ovos_utils.log import LOG
 from ovos_utils.network_utils import is_connected
 
@@ -461,19 +462,24 @@ class MycroftMark1(PHALPlugin):
         if message and message.data:
             start = message.data['start']
             visemes = message.data['visemes']
-            self.showing_visemes = True
-            previous_end = -1
-            for code, end in visemes:
-                if not self.showing_visemes:
-                    break
-                if end < previous_end:
-                    start = time.time()
-                previous_end = end
-                if time.time() < start + end:
-                    self.writer.write('mouth.viseme=' + code)
-                    sleep(start + end - time.time())
-            self.writer.write("mouth.reset")
-            self.showing_visemes = False
+
+            def animate_mouth():
+                self.showing_visemes = True
+                previous_end = -1
+                for code, end in visemes:
+                    if not self.showing_visemes:
+                        break
+                    if end < previous_end:
+                        start = time.time()
+                    previous_end = end
+                    if time.time() < start + end:
+                        self.writer.write('mouth.viseme=' + code)
+                        sleep(start + end - time.time())
+                self.writer.write("mouth.reset")
+                self.showing_visemes = False
+
+            # use a thread to not block FakeBus (eg, voice sat)
+            create_daemon(animate_mouth)
 
     def on_text(self, message=None):
         """Display text (scrolling as needed)


### PR DESCRIPTION
showing visemes in a mark1 voice sat could block TTS from executing, due to the event handlers not being True threads

does not affect regular usage

issue demonstration in voice satellite with a "bad" G2P plugin
https://github.com/OpenVoiceOS/ovos-PHAL-plugin-mk1/assets/33701864/bff13194-f911-4777-af3c-0327c7ed9fa7

