### PR TITLE
added validation using ovos-i2c-detection

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
+        python-version: [ 3.9, "3.10", "3.11" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/ovos_PHAL_plugin_mk1/__init__.py
+++ b/ovos_PHAL_plugin_mk1/__init__.py
@@ -12,6 +12,7 @@ from ovos_utils import create_daemon
 from ovos_utils.log import LOG
 from ovos_utils.network_utils import is_connected
 from ovos_i2c_detection import is_mark_1
+from ovos_config import Configuration
 
 from ovos_PHAL_plugin_mk1.arduino import EnclosureReader, EnclosureWriter
 
@@ -31,6 +32,9 @@ class MycroftMark1Validator:
         """ this method is called before loading the plugin.
         If it returns False the plugin is not loaded.
         This allows a plugin to run platform checks"""
+        cfg = config or Configuration().get("PHAL").get("ovos-PHAL-plugin-mk1")
+        if cfg.get("enabled") == True:
+            return True
         if is_mark_1():
             return True
         return False

--- a/ovos_PHAL_plugin_mk1/__init__.py
+++ b/ovos_PHAL_plugin_mk1/__init__.py
@@ -32,7 +32,7 @@ class MycroftMark1Validator:
         """ this method is called before loading the plugin.
         If it returns False the plugin is not loaded.
         This allows a plugin to run platform checks"""
-        cfg = config or Configuration().get("PHAL").get("ovos-PHAL-plugin-mk1") or None
+        cfg = config or Configuration().get("PHAL", {}).get("ovos-PHAL-plugin-mk1")
         if cfg and cfg.get("enabled") == True:
             return True
         if is_mark_1():

--- a/ovos_PHAL_plugin_mk1/__init__.py
+++ b/ovos_PHAL_plugin_mk1/__init__.py
@@ -33,7 +33,7 @@ class MycroftMark1Validator:
         If it returns False the plugin is not loaded.
         This allows a plugin to run platform checks"""
         cfg = config or Configuration().get("PHAL").get("ovos-PHAL-plugin-mk1")
-        if cfg.get("enabled") == True:
+        if cfg and cfg.get("enabled") == True:
             return True
         if is_mark_1():
             return True

--- a/ovos_PHAL_plugin_mk1/__init__.py
+++ b/ovos_PHAL_plugin_mk1/__init__.py
@@ -32,7 +32,7 @@ class MycroftMark1Validator:
         """ this method is called before loading the plugin.
         If it returns False the plugin is not loaded.
         This allows a plugin to run platform checks"""
-        cfg = config or Configuration().get("PHAL").get("ovos-PHAL-plugin-mk1")
+        cfg = config or Configuration().get("PHAL").get("ovos-PHAL-plugin-mk1") or None
         if cfg and cfg.get("enabled") == True:
             return True
         if is_mark_1():

--- a/ovos_PHAL_plugin_mk1/__init__.py
+++ b/ovos_PHAL_plugin_mk1/__init__.py
@@ -11,6 +11,7 @@ from ovos_plugin_manager.phal import PHALPlugin
 from ovos_utils import create_daemon
 from ovos_utils.log import LOG
 from ovos_utils.network_utils import is_connected
+from ovos_i2c_detection import is_mark_1
 
 from ovos_PHAL_plugin_mk1.arduino import EnclosureReader, EnclosureWriter
 
@@ -30,9 +31,9 @@ class MycroftMark1Validator:
         """ this method is called before loading the plugin.
         If it returns False the plugin is not loaded.
         This allows a plugin to run platform checks"""
-        # TODO how to detect if running in a mark1 ?
-        #  detect "/dev/ttyAMA0" ?
-        return True
+        if is_mark_1():
+            return True
+        return False
 
 
 class MycroftMark1(PHALPlugin):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ovos-plugin-manager>=0.0.24
 ovos-mark1-utils>=0.0.1
 ovos-utils>=0.0.38
+ovos-i2c-detection
 pyserial~=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ovos-plugin-manager>=0.0.24
 ovos-mark1-utils>=0.0.1
 ovos-utils>=0.0.38
-ovos-i2c-detection>=0.0.4
+ovos-i2c-detection>=0.0.5
 pyserial~=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ovos-plugin-manager>=0.0.24
 ovos-mark1-utils>=0.0.1
 ovos-utils>=0.0.38
-ovos-i2c-detection
+ovos-i2c-detection>=0.0.4
 pyserial~=3.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced device validation for Mycroft Mark 1 plugin with improved configuration checks.

- **Dependencies**
  - Added new package `ovos-i2c-detection` to support device detection.
  - Updated Python testing environments to include Python 3.11.

- **Compatibility**
  - Removed support for Python 3.7 and 3.8 in build tests.
  - Maintained support for Python 3.9 and 3.10.
  - Retained existing dependency on `pyserial`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->