### PR TITLE
feat!: migrate emitted bus topic to the OVOS spec namespace

### DIFF
--- a/ovos_PHAL_plugin_mk1/__init__.py
+++ b/ovos_PHAL_plugin_mk1/__init__.py
@@ -8,6 +8,7 @@ from ovos_bus_client.message import Message
 from ovos_mark1.faceplate.icons import MusicIcon, WarningIcon, SnowIcon, StormIcon, SunnyIcon, \
     CloudyIcon, PartlyCloudyIcon, WindIcon, RainIcon, LightRainIcon
 from ovos_plugin_manager.phal import PHALPlugin
+from ovos_spec_tools import SpecMessage
 from ovos_ui_enclosure_protocol import EnclosureProtocolListener
 from ovos_utils import create_daemon
 from ovos_utils.log import LOG
@@ -206,7 +207,7 @@ class MycroftMark1(PHALPlugin):
         if self.speaking or self.listening:
             self.bus.emit(Message("mycroft.stop"))
         else:
-            self.bus.emit(Message("mycroft.mic.listen"))
+            self.bus.emit(Message(SpecMessage.MIC_LISTEN))
 
     def on_music(self, message: Optional[Message] = None):
         MusicIcon(bus=self.bus).display()
@@ -255,7 +256,7 @@ class MycroftMark1(PHALPlugin):
 
     def on_awake(self, message: Optional[Message] = None):
         ''' on wakeup animation
-        triggered by "mycroft.awoken"
+        triggered by "ovos.listener.awoken"
         '''
         self.writer.write("eyes.reset")
         sleep(1)
@@ -266,7 +267,7 @@ class MycroftMark1(PHALPlugin):
 
     def on_sleep(self, message: Optional[Message] = None):
         ''' on naptime animation
-        triggered by "recognizer_loop:sleep"
+        triggered by "ovos.listener.sleep"
         '''
         # Dim and look downward to 'go to sleep'
         # TODO: Get current brightness from somewhere
@@ -440,7 +441,7 @@ class MycroftMark1(PHALPlugin):
     # Display (faceplate) messages
     def on_display_reset(self, message: Optional[Message] = None):
         """Restore the mouth display to normal (blank)
-        triggered by "enclosure.mouth.reset" / "recognizer_loop:record_end"
+        triggered by "enclosure.mouth.reset" / "ovos.listener.record.ended"
         """
         self.writer.write("mouth.reset")
 
@@ -458,7 +459,7 @@ class MycroftMark1(PHALPlugin):
 
     def on_listen(self, message: Optional[Message] = None):
         """Show a 'thinking' image or animation
-        triggered by "enclosure.mouth.listen" / "recognizer_loop:record_begin"
+        triggered by "enclosure.mouth.listen" / "ovos.listener.record.started"
         """
         self.writer.write("mouth.listen")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ classifiers = [
 ]
 dependencies = [
     "ovos-plugin-manager>=3.0.0a1,<4.0.0",
+    "ovos-bus-client>=2.2.0a1,<3.0.0",
+    "ovos-spec-tools>=0.9.0a1,<1.0.0",
     "ovos-ui-enclosure-protocol>=0.0.1a1",
     "ovos-mark1-utils>=0.0.1",
     "ovos-utils>=0.0.38,<1.0.0",

--- a/test/unittests/test_mk1_enclosure.py
+++ b/test/unittests/test_mk1_enclosure.py
@@ -39,6 +39,7 @@ def _stub_hardware_modules():
 
 _stub_hardware_modules()
 
+from ovos_spec_tools import SpecMessage  # noqa: E402
 from ovos_PHAL_plugin_mk1 import MycroftMark1  # noqa: E402
 from ovos_ui_enclosure_protocol import EnclosureProtocolListener  # noqa: E402
 
@@ -107,7 +108,7 @@ class TestMk1UsesComposition(unittest.TestCase):
         plugin = _bare_plugin()
         bus = FakeBus()
         plugin.enclosure = _wire(plugin, bus)
-        bus.emit_event("recognizer_loop:record_begin")  # on_record_begin -> on_listen
+        bus.emit_event(SpecMessage.LISTENER_RECORD_STARTED)  # on_record_begin -> on_listen
         plugin.writer.write.assert_called_with("mouth.listen")
         self.assertTrue(plugin.listening)
 
@@ -120,7 +121,7 @@ class TestMk1MouthGating(unittest.TestCase):
 
         # gating off: on_audio_output_start must not drive a talk animation
         plugin.enclosure.deactivate_mouth_events()
-        bus.emit_event("recognizer_loop:audio_output_start")
+        bus.emit_event(SpecMessage.AUDIO_OUTPUT_STARTED)
         self.assertTrue(plugin.speaking)
         talk_calls = [c for c in plugin.writer.write.call_args_list
                       if c.args and c.args[0] == "mouth.talk"]
@@ -128,7 +129,7 @@ class TestMk1MouthGating(unittest.TestCase):
 
         # gating on: now it drives the talk animation
         plugin.enclosure.activate_mouth_events()
-        bus.emit_event("recognizer_loop:audio_output_start")
+        bus.emit_event(SpecMessage.AUDIO_OUTPUT_STARTED)
         plugin.writer.write.assert_called_with("mouth.talk")
 
 


### PR DESCRIPTION
## What

`handle_button_press` now emits `SpecMessage.MIC_LISTEN` (`ovos.mic.listen`) instead of the legacy `mycroft.mic.listen`.

That is the only real bus topic the plugin *emits* that is in the migration map. The other emits (`mycroft.stop`, `mycroft.<ser>.is_ready`, `system.factory.reset.register`) are not mapped and are left unchanged. The record/speak/wake/sleep lifecycle topics the plugin *reacts* to are owned by the listener in `ovos-ui-enclosure-protocol` (migrated in its companion PR) — the plugin only references those by callback name, so no change is needed beyond updating the test's emitted topics.

## Packaging
- adds `ovos-spec-tools>=0.9.0a1` and `ovos-bus-client>=2.2.0a1` as direct dependencies

## Tests
`test/unittests/test_mk1_enclosure.py` now emits the spec topics (`LISTENER_RECORD_STARTED`, `AUDIO_OUTPUT_STARTED`). Hardware deps (serial / ovos_mark1 / ovos_i2c_detection) are stubbed at import as before. All 4 tests pass locally.

## Notes
- **Stacked on `feat/enclosure-protocol-listener`** (PR #39, the composition refactor); base is that branch, not `dev`, so this diff is scoped to the migration. Rebase onto `dev` once the parent lands.
- Companion PR: `OpenVoiceOS/ovos-ui-enclosure-protocol#3` (migrates the listener's `CORE_EVENTS`).
- **CI RED until `ovos-spec-tools#26` + `ovos-bus-client#230` publish** — `SpecMessage` is not in the published `ovos-spec-tools` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)